### PR TITLE
Optimise preformance for when no constraints > no variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,17 @@
 Package: ROI.plugin.lpsolve
-Version: 1.0-0
+Version: 1.0-1
 Title: 'lp_solve' Plugin for the 'R' Optimization Infrastructure
 Author: Florian Schwendinger [aut, cre]
 Maintainer: Florian Schwendinger <FlorianSchwendinger@gmx.at>
 Description: Enhances the 'R' Optimization Infrastructure ('ROI') package
              with the 'lp_solve' solver.
-Imports: stats, methods, utils, ROI (>= 0.3-0), lpSolveAPI (>= 5.5.2.0-1)
+Imports: stats, methods, utils, ROI (>= 0.3-0), lpSolveAPI (>=
+        5.5.2.0-1)
 Suggests: slam
 License: GPL-3
-URL: http://roi.r-forge.r-project.org/, https://r-forge.r-project.org/projects/roi/
+URL: http://roi.r-forge.r-project.org/,
+        https://github.com/roigrp/ROI.plugin.lpsolve
+NeedsCompilation: no
+Packaged: 2021-06-14 14:21:11 UTC; f
+Repository: CRAN
+Date/Publication: 2021-06-15 05:10:07 UTC

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -77,8 +77,29 @@ is.all_integer <- function(types) {
     all(types %in% c("B", "I"))
 }
 
+
+# NOTE: 
+#   We used here get.variables but we got reports that when using presolve this
+#   can result in getting more variables than the original problem has.
+#   This should be resolved by using get.primal.solution with setting orig
+#   to TRUE.
+get_primal_solution <- function(lprec, n_of_variables) {
+    # get.variables(lprec)
+    primal_solution <- get.primal.solution(lprec, orig = TRUE)
+    if (is.null(primal_solution)) {
+        primal_solution <- get.variables(lprec)
+    } else {
+        # get.primal.solution gives the lhs of the evaluated constraints
+        # and the primal solution, therfore the length is n_of_constraints + n_of_variables.
+        primal_solution <- tail(primal_solution, n_of_variables)
+    }
+    primal_solution
+}
+
+
 solve_OP <- function(x, control = list()) {
     solver <- "lpsolve"
+    use_presolve <- "presolve" %in% names(control)
 
     nr <- length(constraints(x))
     nc <- length(objective(x))
@@ -87,16 +108,23 @@ solve_OP <- function(x, control = list()) {
     om <- make.lp(nr, nc, verbose = control$verbose)
 
     ## objective
-    set.objfn(om, terms(objective(x))[['L']]$v, terms(objective(x))[['L']]$j)
-    
+    # mat <- as.matrix(constraints(x)[['L']])
     ## constraints
-    for (i in seq_len(nr)) {
-        irow <- constraints(x)[['L']][i,]
-        set.row(om, i, irow$v, irow$j)
+    if(nr < nc){
+        for (i in seq_len(nr)) {
+            irow <- constraints(x)[['L']][i,]
+            set.row(om, i, irow$v, irow$j)
+        }
+    }else {
+        for (k in seq_len(nc)) {
+            kcol <- constraints(x)[['L']][,k]
+            set.column(om, k,kcol$v, kcol$i)
+        }
     }
     set.rhs(om, constraints(x)[['rhs']], seq_len(nr))
     set.constr.type(om, map_dir(constraints(x)[['dir']]), seq_len(nr))
 
+    # set.objfn(om, terms(objective(x))[['L']]$v, terms(objective(x))[['L']]$j)
     ## bounds (lp_solve has the lower bound default by zero)
     if ( !is.null(bounds(x)) ) {
         bo <- build_bounds(bounds(x))
@@ -115,6 +143,8 @@ solve_OP <- function(x, control = list()) {
     ## maximum
     control$sense <- if (x$maximum) "max" else "min"
 
+    # set.objfn(om, terms(objective(x))[['L']]$v)
+    set.objfn(om, terms(objective(x))[['L']]$v,  terms(objective(x))[['L']]$j)
     ## control options
     ## - basis 
     ##     list(basis = c(1, 2, 3), nonbasic = TRUE, default = TRUE)
@@ -166,7 +196,7 @@ solve_OP <- function(x, control = list()) {
             sol$dual_solutions <- vector("list", sol$solution_count)
             for ( i in seq_len(sol$solution_count) ) {
                 select.solution(om, i)
-                sol$solutions[[i]] <- get.variables(om)
+                sol$solutions[[i]] <- get_primal_solution(om, n_of_variables = nc)
                 sol$dual_solutions[[i]] <- get.dual.solution(om)
             }
         
@@ -194,11 +224,11 @@ solve_OP <- function(x, control = list()) {
     }
 }
 
-lp_solve <- function(om) {
+lp_solve <- function(om, n_of_variables) {
     status <- solve(om)
     x <- vector("list", 5)
     names(x) <- c("solution", "optimum", "status", "solver", "message")
-    x[["solution"]] <- get.variables(om)
+    x[["solution"]] <- get_primal_solution(om, n_of_variables)
     x[["optimum"]] <- get.objective(om)
     x[["status"]] <- status
     x[["solver"]] <- "lpsolve"
@@ -215,13 +245,14 @@ objective_value <- function(obj_fun, solution) {
 
 ## nsol <- control$nsol
 .find_up_to_n_binary_MILP_solutions <- function(om, x, nsol, tolerance = 1e-4) {
+    n_of_variables <- length(objective(x))
     k <- which(types(x) == "B")
     if ( length(k) == 0 ) {
         stop("no 'binary' variables found")
     }
 
     solutions <- vector("list", nsol)
-    solutions[[1L]] <- lp_solve(om)
+    solutions[[1L]] <- lp_solve(om, n_of_variables)
     if ( solutions[[1L]]$status$code != 0 ) {
         return(solutions[1L])
     }
@@ -237,7 +268,7 @@ objective_value <- function(obj_fun, solution) {
         ak[sol == 0] <- -1
         add.constraint(om, xt = ak, type = "<=", rhs = rhs, indices = k)
 
-        sobj <- lp_solve(om)
+        sobj <- lp_solve(om, n_of_variables)
         if ( sobj$status$code != 0 ) {
             return(solutions)
         }
@@ -317,4 +348,18 @@ read.lp <- function(file, type=c("lp", "mps", "freemps")) {
             types = ty, bounds = bo, maximum = is_maxi)
     x
 }
+
+
+library(lpSolveAPI)
+
+lps.model <- make.lp(0, 3)
+# xt <- c(6,2,4)
+# add.constraint(lps.model, xt, "<=", 150)
+# xt <- c(1,1,6)
+# add.constraint(lps.model, xt, ">=", 0)
+# xt <- c(4,5,4)
+# add.constraint(lps.model, xt, "=", 40)
+set.objfn(lps.model, c(-3,-4,-3))
+
+solve(lps.model)
 

--- a/R/plugin.R
+++ b/R/plugin.R
@@ -115,7 +115,7 @@ solve_OP <- function(x, control = list()) {
             irow <- constraints(x)[['L']][i,]
             set.row(om, i, irow$v, irow$j)
         }
-    }else {
+    }else{
         for (k in seq_len(nc)) {
             kcol <- constraints(x)[['L']][,k]
             set.column(om, k,kcol$v, kcol$i)
@@ -142,9 +142,11 @@ solve_OP <- function(x, control = list()) {
 
     ## maximum
     control$sense <- if (x$maximum) "max" else "min"
-
-    # set.objfn(om, terms(objective(x))[['L']]$v)
-    set.objfn(om, terms(objective(x))[['L']]$v,  terms(objective(x))[['L']]$j)
+    if(length(terms(objective(x))[['L']]$j == nc)){
+        set.objfn(om, terms(objective(x))[['L']]$v)
+    }else{
+        set.objfn(om, terms(objective(x))[['L']]$v,  terms(objective(x))[['L']]$j)
+    }
     ## control options
     ## - basis 
     ##     list(basis = c(1, 2, 3), nonbasic = TRUE, default = TRUE)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,5 @@
 Patched version of ROI.lpsolve, improves performance when there are more constraints than variables 
 
 ```r
-# remotes:::install_github("roigrp/ROI.plugin.lpsolve")
-remotes:::install_github("marcishak/ROI.plugin.lpsolve")
+remotes:::install_github("roigrp/ROI.plugin.lpsolve")
 ```

--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@ Patched version of ROI.lpsolve, improves performance when there are more constra
 
 ```r
 remotes:::install_github("roigrp/ROI.plugin.lpsolve")
+remotes:::install_github("marcishak/ROI.plugin.lpsolve")
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # ROI.plugin.lpsolve
-lp_solve Plugin for the R Optimization Infrastructure
+
+# Installation from Github
+
+Patched version of ROI.lpsolve, improves performance when there are more constraints than variables 
+
+```r
+# remotes:::install_github("roigrp/ROI.plugin.lpsolve")
+remotes:::install_github("marcishak/ROI.plugin.lpsolve")
+```


### PR DESCRIPTION
A simple fix to optimise performance when the number of constraints is greater than the number of variables.


Core code is

    if(nr < nc){
        for (i in seq_len(nr)) {
            irow <- constraints(x)[['L']][i,]
            set.row(om, i, irow$v, irow$j)
        }
    }else {
        for (k in seq_len(nc)) {
            kcol <- constraints(x)[['L']][,k]
            set.column(om, k,kcol$v, kcol$i)
        }
    }


and move of   `set.objfn(om, terms(objective(x))[['L']]$v, terms(objective(x))[['L']]$j)` later down the script.  